### PR TITLE
Fix release of primary keycodes

### DIFF
--- a/src/Kaleidoscope/Qukeys.cpp
+++ b/src/Kaleidoscope/Qukeys.cpp
@@ -312,7 +312,8 @@ EventHandlerResult Qukeys::onKeyswitchEvent(Key &mapped_key, byte row, byte col,
     }
     flushQueue(queue_index);
     flushQueue();
-    return EventHandlerResult::EVENT_CONSUMED;
+    mapped_key = getDualUsePrimaryKey(mapped_key);
+    return EventHandlerResult::OK;
   }
 
   // Otherwise, the key is still pressed


### PR DESCRIPTION
When a key was released, we were failing to send the release event explicitly. For most
plugins, this didn't matter, but it was causing a problem for Leader, which acts on
release events. By returning `EVENT_CONSUMED` instead of `OK`, we were stopping the
release event from getting through to Leader, and thus a qukey with a Leader key as its
primary keycode would fail.

Fixes #46